### PR TITLE
トークン作成時にCookieに保存

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,21 +4,24 @@ class ApplicationController < ActionController::API
   protected
 
   def authenticate_request
-    header = request.headers['Authorization']
-    header = header.split(' ').last if header
-    begin
-      @decoded = JwtService.decode(header)
-      if @decoded['provider'] == 'guest'
-        @current_user = User.find(@decoded['user_id'])
-      else
-        user_auth = UserAuthentication.find_by(uid: @decoded['google_user_id'], provider: @decoded['provider'])
-        @current_user = user_auth.user if user_auth
+    token = cookies.signed[:auth_token]
+    if token
+      begin
+        @decoded = JwtService.decode(token)
+        if @decoded['provider'] == 'guest'
+          @current_user = User.find(@decoded['user_id'])
+        else
+          user_auth = UserAuthentication.find_by(uid: @decoded['google_user_id'], provider: @decoded['provider'])
+          @current_user = user_auth.user if user_auth
+        end
+        Rails.logger.info(@current_user)
+        raise ActiveRecord::RecordNotFound, 'User not found' unless @current_user
+      rescue ActiveRecord::RecordNotFound, JWT::DecodeError => e
+        Rails.logger.error "認証エラー: #{e.message}"
+        render json: { redirect_url: "#{ENV['NEXT_PUBLIC_API_URL']}/pages/login" }, status: :unauthorized
       end
-      Rails.logger.info(@current_user)
-      raise ActiveRecord::RecordNotFound, 'User not found' unless @current_user
-    rescue ActiveRecord::RecordNotFound, JWT::DecodeError => e
-      Rails.logger.error "認証エラー: #{e.message}"
-      render json: { errors: e.message }, status: :unauthorized
+    else
+      render json: { redirect_url: "#{ENV['NEXT_PUBLIC_API_URL']}/pages/login" }, status: :unauthorized
     end
   end
 end


### PR DESCRIPTION
## 概要

Google OAuth認証後のセッション管理と認証状態の確認のために、`SessionsController`の処理を実装および修正しました。また、フロントエンドとバックエンドでユーザーの認証状態を管理するために、認証トークンをCookieに保存し、リクエストごとに認証を確認する機能を追加しました。

## 変更内容

1. **`SessionsController`の実装**:
    - Google OAuth認証後に、ユーザーが既にアプリに登録されているかどうかを確認する処理を追加しました。
    - 認証に成功した場合、JWTトークンを生成し、それを`auth_token`としてCookieに保存するようにしました。
    - トークンは24時間有効で、`httponly`属性を設定し、JavaScriptからのアクセスを制限しています。
    - トークンを保存後、フロントエンドのトップページ (`/pages/top`) へリダイレクトします。
2. **`ApplicationController`の修正**:
    - リクエストごとにCookieからトークンを取得し、ユーザーの認証状態を確認する処理を追加しました。
    - 認証トークンが無効または存在しない場合、ログインページ (`/pages/login`) にリダイレクトする処理を追加しました。

## 動作確認

- ログイン後、`auth_token`がCookieに正しく保存されていることをブラウザの開発者ツールを使用して確認しました。
- トップページ (`/pages/top`) へのリダイレクトが正しく行われることを確認しました。
- 未認証状態で保護されたページにアクセスした場合、ログインページにリダイレクトされることを確認しました。

## その他
